### PR TITLE
casted height to `double` from `int`

### DIFF
--- a/lib/ad/ad_native.dart
+++ b/lib/ad/ad_native.dart
@@ -229,7 +229,7 @@ class _FacebookNativeAdState extends State<FacebookNativeAd>
         width: width,
         height: widget.adType == NativeAdType.NATIVE_AD
             ? widget.height
-            : widget.bannerAdSize.height.toInt(),
+            : widget.bannerAdSize.height.toDouble(),
         child: UiKitView(
           viewType: _getChannelRegisterId(),
           onPlatformViewCreated: _onNativeAdViewCreated,


### PR DESCRIPTION
The `height` of the Container is double but it was casted to `int`. 

Below is the Flutter error

```
════════ Exception caught by widgets library ═══════════════════════════════════════════════════════
The following _TypeError was thrown building FacebookNativeAd(dirty, dependencies: [MediaQuery], state: _FacebookNativeAdState#5c040):
type 'int' is not a subtype of type 'double'

The relevant error-causing widget was: 
  FacebookNativeAd file:///Users/<Path-to-file>/xyz.dart:13:12
When the exception was thrown, this was the stack: 
#0      _FacebookNativeAdState.buildPlatformView (package:facebook_audience_network/ad/ad_native.dart:231:13)
#1      _FacebookNativeAdState.build (package:facebook_audience_network/ad/ad_native.dart:175:22)
#2      StatefulElement.build (package:flutter/src/widgets/framework.dart:4744:28)
#3      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4627:15)
#4      StatefulElement.performRebuild (package:flutter/src/widgets/framework.dart:4800:11)

```